### PR TITLE
Handle empty style properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ function camelToDash(str) {
             .replace(/([a-z\d])([A-Z])/g, '$1-$2');
 }
 
+function removeEmpties(n) {
+  return n != '';
+}
+
 // shameless stolen from https://github.com/punkave/sanitize-html
 function escapeHtml(s, replaceDoubleQuote) {
   if (s === 'undefined') {
@@ -48,10 +52,10 @@ function createAttrString(attrs) {
       var styles = attrs.style;
       if (typeof styles === 'object') {
         styles = Object.keys(styles).map(function(property) {
-          return [camelToDash(property).toLowerCase(), styles[property]].join(':');
-        }).join(';');
+          return styles[property] != '' ? [camelToDash(property).toLowerCase(), styles[property]].join(':') : '';
+        }).filter(removeEmpties).join(';');
       }
-      return ' style="' + escapeHtml(styles, true) + '"';
+      return styles != '' ? ' style="' + escapeHtml(styles, true) + '"' : '';
     }
     return ' ' + escapeHtml(name === 'className' ? 'class' : name) + '="' + escapeHtml(value, true) + '"';
   }).join('');

--- a/test.js
+++ b/test.js
@@ -46,6 +46,9 @@ test('render', function(t) {
   t.equal(render(m('div', { a: undefined})), '<div></div>');
   t.equal(render(m('div', { style: null })), '<div></div>');
   t.equal(render(m('div', { style: '' })), '<div></div>');
+  t.equal(render(m('div', { style: { color: '' } })), '<div></div>');
+  t.equal(render(m('div', { style: { height: '20px', color: '' } })), '<div style="height:20px"></div>');
+  t.equal(render(m('div', { style: { height: '20px', color: '', width: '10px' } })), '<div style="height:20px;width:10px"></div>');
   t.equal(render(m('div', { a: 'foo'})), '<div a="foo"></div>');
   t.equal(render(m('div', m.trust('<foo></foo>'))), '<div><foo></foo></div>');
   t.equal(render(m('div', '<foo></foo>')), '<div>&lt;foo&gt;&lt;/foo&gt;</div>');


### PR DESCRIPTION
Noticed passing an empty value for a style property creates unwanted results, e.g.:

    m('div', { style: { color: 'red', textDecoration: '' } })
    <div style="color:red;text-decoration:">Foobar</div>

Reference for updated behaviour:
https://jsfiddle.net/mb64ckyn/1/