### PR TITLE
Bring the lifecycle hooks closer to the real thing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node rending of mithril views",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/tape/bin/tape test.js"
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/StephanHoyer/mithril-node-render",
   "devDependencies": {
-    "mithril": "git://github.com/lhorie/mithril.js.git#rewrite",
-    "tape": "4.5.1"
+    "mithril": "git://github.com/lhorie/mithril.js.git#rewrite"
   }
 }


### PR DESCRIPTION
My initial plan was to pass `vnode.state` as the context for the view and the hooks, but then I got a bit carried away...

The patches should be inspected piecewise.

The first and the third one are trivial, but they add noise to the second one which contains the meat of the PR.

Most of the assertions added in the second commit were failing (the exceptions being the ones that ensure that `render` runs properly).