### PR TITLE
Allow npm run test to run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node rending of mithril views",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/tape/bin/tape test.js"
+    "test": "tape test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
On Windows, "node_modules" doesn't resolve (it needs to be "./node_modules") - however this is unnecessary since npm scripts treat the contents of node_modules as if they were on the path without needing global installs.