### PR TITLE
Handing mithril 1.1.1 closure components rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ function isObject (thing) {
   return typeof thing === 'object'
 }
 
+function isFunction (thing) {
+  return typeof thing === 'function'
+}
+
 function camelToDash (str) {
   return str.replace(/\W+/g, '-')
     .replace(/([a-z\d])([A-Z])/g, '$1-$2')
@@ -166,6 +170,9 @@ function * _render (view, options, hooks) {
   var component = view.view
   if (isObject(view.tag)) {
     component = view.tag
+  }
+  if (isFunction(view.tag)) {
+    component = view.tag()
   }
   // component
   if (component) {

--- a/test.js
+++ b/test.js
@@ -321,4 +321,15 @@ o.spec('async', function () {
   })
 })
 
+o.async('render closure components', function * () {
+  var closureComponent = function () {
+    return {
+      view: function(node) {
+        return m('p','p')
+      }
+    }
+  }
+  o(yield render(closureComponent())).equals('<p>p</p>')
+})
+
 o.run()


### PR DESCRIPTION
Mithril 1.1.1 introduced "closure component" syntax. https://mithril.js.org/components.html#closure-components

mithril-node-render fails with the following error for closure component

`TypeError: view.tag.toLowerCase is not a function`
`     at _render (node_modules/mithril-node-render/index.js:192:66)`

I have fixed it in this pull request by checking for view.tag to be a function and calling it to get the component. 
Please let me know if this needs any change.